### PR TITLE
[ROY-24] Change font size for description in the cards

### DIFF
--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -107,17 +107,18 @@
 }
 
 .sandbox-card-description {
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.5;
   margin-bottom: 5px;
   transition: margin-bottom $transition-time;
 
   @include media-breakpoint-up(sm) {
+    font-size: 12px;
     margin-bottom: 10px;
   }
 
   @include media-breakpoint-up(lg) {
-    font-size: 12px;
+    font-size: 14px;
     margin-bottom: 15px;
   }
 }


### PR DESCRIPTION
Issue: https://github.com/ymcatwincities/openy/issues/2297

### How to review:
- [ ] Go to Front Page 
- [ ] Make sure that font size for description in the cards is `14px` for large display, and `12px` for mobile and tablet.
![image](https://user-images.githubusercontent.com/22738130/101026768-fdcb2600-357f-11eb-8504-2f75b72b9f4d.png)